### PR TITLE
Fix: Resolve TypeScript build errors in frontend

### DIFF
--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -6,6 +6,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "types": ["vite/client"],
 
     /* Bundler mode */
     "moduleResolution": "bundler",
@@ -23,5 +24,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src", "src/vite-env.d.ts"]
 }


### PR DESCRIPTION
This commit addresses two main issues that caused the frontend build to fail:

1.  **CSS Module Type Errors:** TypeScript was unable to find type declarations for `.module.css` and `.css` files. This was resolved by:
    *   Creating a `frontend/src/vite-env.d.ts` file with appropriate type declarations for these file types.
    *   Including this new declaration file in the `include` array of `frontend/tsconfig.app.json`.

2.  **`import.meta.env` Type Errors:** TypeScript did not recognize the `import.meta.env` object used by Vite for environment variables. This was fixed by:
    *   Adding `"vite/client"` to the `compilerOptions.types` array in `frontend/tsconfig.app.json`.

These changes should allow the frontend to build successfully.