### PR TITLE
Fix: Sanitize Terraform output and update deployment trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       BACKEND_IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/backend
       GCP_REGION: europe-west1 # Set region to europe-west1
       TERRAFORM_DIR: ./terraform # Assuming terraform files are in a 'terraform' directory at the root
+      TF_CLI_ARGS: "-no-color"
 
     steps:
       - name: Checkout code
@@ -77,16 +78,15 @@ jobs:
       - name: Terraform Init
         run: terraform -chdir=${{ env.TERRAFORM_DIR }} init
 
+      - name: Terraform Apply
+        run: terraform -chdir=${{ env.TERRAFORM_DIR }} apply -auto-approve
+
       - name: Terraform Output Frontend Service Name
         id: tf_frontend_service
-        env:
-          TF_CLI_ARGS: "-no-color"
         run: echo "name=$(terraform -chdir=${{ env.TERRAFORM_DIR }} output -raw frontend_cloud_run_service_name | sed -E 's/\x1B\[[0-9;]*[mK]//g; s/^[^a-zA-Z0-9]*//')" >> $GITHUB_OUTPUT
 
       - name: Terraform Output Backend Service Name
         id: tf_backend_service
-        env:
-          TF_CLI_ARGS: "-no-color"
         run: echo "name=$(terraform -chdir=${{ env.TERRAFORM_DIR }} output -raw backend_cloud_run_service_name | sed -E 's/\x1B\[[0-9;]*[mK]//g; s/^[^a-zA-Z0-9]*//')" >> $GITHUB_OUTPUT
 
       # Frontend Deployment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,15 @@ jobs:
 
       - name: Terraform Output Frontend Service Name
         id: tf_frontend_service
-        run: echo "name=$(terraform -chdir=${{ env.TERRAFORM_DIR }} output -raw frontend_cloud_run_service_name | sed 's/^[^a-zA-Z0-9]*//')" >> $GITHUB_OUTPUT
+        env:
+          TF_CLI_ARGS: "-no-color"
+        run: echo "name=$(terraform -chdir=${{ env.TERRAFORM_DIR }} output -raw frontend_cloud_run_service_name | sed -E 's/\x1B\[[0-9;]*[mK]//g; s/^[^a-zA-Z0-9]*//')" >> $GITHUB_OUTPUT
 
       - name: Terraform Output Backend Service Name
         id: tf_backend_service
-        run: echo "name=$(terraform -chdir=${{ env.TERRAFORM_DIR }} output -raw backend_cloud_run_service_name | sed 's/^[^a-zA-Z0-9]*//')" >> $GITHUB_OUTPUT
+        env:
+          TF_CLI_ARGS: "-no-color"
+        run: echo "name=$(terraform -chdir=${{ env.TERRAFORM_DIR }} output -raw backend_cloud_run_service_name | sed -E 's/\x1B\[[0-9;]*[mK]//g; s/^[^a-zA-Z0-9]*//')" >> $GITHUB_OUTPUT
 
       # Frontend Deployment
       - name: Build Frontend Docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,6 @@ jobs:
       - name: Authenticate to Google Cloud via Workload Identity Federation
         uses: 'google-github-actions/auth@v2'
         with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }} # e.g. projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider
           service_account: ${{ secrets.SERVICE_ACCOUNT_EMAIL }} # e.g. my-service-account@my-project.iam.gserviceaccount.com
 
@@ -73,6 +72,8 @@ jobs:
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v2
+        # with:
+        #   terraform_version: "1.0.0" # Optional: specify Terraform version
 
       - name: Terraform Init
         run: terraform -chdir=${{ env.TERRAFORM_DIR }} init

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "fix/deployment-error" ]
   pull_request:
     branches: [ "**" ] # Run on all branches for PRs
 
@@ -40,7 +40,7 @@ jobs:
     name: Build and Deploy to Cloud Run
     runs-on: ubuntu-latest
     needs: lint-test-build # Ensure lint, test, and build pass before deploying
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/fix/deployment-error' && github.event_name == 'push'
 
     permissions: # Needed for Workload Identity Federation
       contents: 'read'
@@ -79,11 +79,11 @@ jobs:
 
       - name: Terraform Output Frontend Service Name
         id: tf_frontend_service
-        run: echo "name=$(terraform -chdir=${{ env.TERRAFORM_DIR }} output -raw frontend_cloud_run_service_name)" >> $GITHUB_OUTPUT
+        run: echo "name=$(terraform -chdir=${{ env.TERRAFORM_DIR }} output -raw frontend_cloud_run_service_name | sed 's/^[^a-zA-Z0-9]*//')" >> $GITHUB_OUTPUT
 
       - name: Terraform Output Backend Service Name
         id: tf_backend_service
-        run: echo "name=$(terraform -chdir=${{ env.TERRAFORM_DIR }} output -raw backend_cloud_run_service_name)" >> $GITHUB_OUTPUT
+        run: echo "name=$(terraform -chdir=${{ env.TERRAFORM_DIR }} output -raw backend_cloud_run_service_name | sed 's/^[^a-zA-Z0-9]*//')" >> $GITHUB_OUTPUT
 
       # Frontend Deployment
       - name: Build Frontend Docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
       - name: Authenticate to Google Cloud via Workload Identity Federation
         uses: 'google-github-actions/auth@v2'
         with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }} # e.g. projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider
           service_account: ${{ secrets.SERVICE_ACCOUNT_EMAIL }} # e.g. my-service-account@my-project.iam.gserviceaccount.com
 
@@ -72,8 +73,6 @@ jobs:
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v2
-        # with:
-        #   terraform_version: "1.0.0" # Optional: specify Terraform version
 
       - name: Terraform Init
         run: terraform -chdir=${{ env.TERRAFORM_DIR }} init

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         run: terraform -chdir=${{ env.TERRAFORM_DIR }} init
 
       - name: Terraform Apply
-        run: terraform -chdir=${{ env.TERRAFORM_DIR }} apply -auto-approve
+        run: terraform -chdir=${{ env.TERRAFORM_DIR }} apply -auto-approve -var="gcp_project_id=${{ env.GCP_PROJECT_ID }}" -var="gcp_region=${{ env.GCP_REGION }}"
 
       - name: Terraform Output Frontend Service Name
         id: tf_frontend_service

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,12 @@
+terraform {
+  backend "gcs" {
+    bucket  = "acadojo"
+    prefix  = "terraform/state"
+  }
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -11,6 +11,6 @@ provider "google" {
   # Configuration options for the provider, e.g., project, region
   # These will typically be configured via environment variables or a backend config
   # For now, we'll leave them to be implicitly configured or use TF_VAR_ environment variables
-  # project = var.gcp_project_id
-  # region  = var.gcp_region
+  project = var.gcp_project_id
+  region  = var.gcp_region
 }

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,16 +1,4 @@
-terraform {
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = "~> 5.0"
-    }
-  }
-}
-
 provider "google" {
-  # Configuration options for the provider, e.g., project, region
-  # These will typically be configured via environment variables or a backend config
-  # For now, we'll leave them to be implicitly configured or use TF_VAR_ environment variables
   project = var.gcp_project_id
   region  = var.gcp_region
 }


### PR DESCRIPTION
- Sanitize Terraform output for Cloud Run service names to prevent errors from leading special characters.
- Modify the build-and-deploy job to trigger on pushes to the fix/deployment-error branch for isolated testing.